### PR TITLE
Increase workflows per agent

### DIFF
--- a/host_vars/ci_server.yaml
+++ b/host_vars/ci_server.yaml
@@ -23,7 +23,7 @@ woodpecker_autoscaler_server_url: http://woodpecker-server:8000
 woodpecker_autoscaler_server_token: '{{ vault_woodpecker_api_token }}'
 woodpecker_autoscaler_min_agents: 0
 woodpecker_autoscaler_max_agents: 1
-woodpecker_autoscaler_workflows_per_agent: 2
+woodpecker_autoscaler_workflows_per_agent: 4
 woodpecker_autoscaler_grpc_addr: grpc-ci.woodpecker-ci.org:443
 woodpecker_autoscaler_grpc_secure: true
 woodpecker_autoscaler_provider: hetznercloud


### PR DESCRIPTION
As discussed in matrix.

To find a reasonable value WRT to memory capacity, one would need to monitor how much memory a "full" CI run needs.