### PR TITLE
Disable version check for WP GH instance

### DIFF
--- a/roles/woodpecker_server/tasks/main.yaml
+++ b/roles/woodpecker_server/tasks/main.yaml
@@ -28,6 +28,7 @@
       WOODPECKER_GITHUB_SECRET: '{{ woodpecker_server_github_secret | string }}'
       WOODPECKER_AGENT_SECRET: '{{ woodpecker_server_agent_secret | string }}'
       WOODPECKER_GITHUB_MERGE_REF: 'false'
+      WOODPECKER_DISABLE_VERSION_CHECK: 'true'
   tags:
     - woodpecker
     - woodpecker-server


### PR DESCRIPTION
To get rid of the red dot.