### PR TITLE
community.docker.docker_container migrate pull from enum to bool

### DIFF
--- a/roles/woodpecker_agent/tasks/main.yaml
+++ b/roles/woodpecker_agent/tasks/main.yaml
@@ -11,7 +11,7 @@
   community.docker.docker_container:
     name: woodpecker_agent
     hostname: woodpecker_agent
-    pull: 'always'
+    pull: true
     image: woodpeckerci/woodpecker-agent:{{ woodpecker_agent_version }}
     restart_policy: 'always'
     networks:

--- a/roles/woodpecker_autoscaler/tasks/main.yaml
+++ b/roles/woodpecker_autoscaler/tasks/main.yaml
@@ -2,7 +2,7 @@
   community.docker.docker_container:
     name: woodpecker_autoscaler
     hostname: woodpecker-autoscaler
-    pull: 'always'
+    pull: true
     image: woodpeckerci/autoscaler:{{ woodpecker_autoscaler_version }}
     restart_policy: 'always'
     networks:

--- a/roles/woodpecker_server/tasks/main.yaml
+++ b/roles/woodpecker_server/tasks/main.yaml
@@ -11,7 +11,7 @@
   community.docker.docker_container:
     name: woodpecker_server
     hostname: woodpecker-server
-    pull: 'always'
+    pull: true
     image: woodpeckerci/woodpecker-server:{{ woodpecker_server_version }}
     restart_policy: 'always'
     volumes:


### PR DESCRIPTION
"fatal: [ci_server]: FAILED! => {"changed": false, "msg": "argument 'pull' is of type <class 'str'> and we were unable to convert to bool:"