### PR TITLE
update WOODPECKER_PLUGINS_PRIVILEGED

### DIFF
--- a/roles/woodpecker_server/tasks/main.yaml
+++ b/roles/woodpecker_server/tasks/main.yaml
@@ -28,7 +28,7 @@
       WOODPECKER_GITHUB_SECRET: '{{ woodpecker_server_github_secret | string }}'
       WOODPECKER_AGENT_SECRET: '{{ woodpecker_server_agent_secret | string }}'
       WOODPECKER_GITHUB_MERGE_REF: 'false'
-      WOODPECKER_PLUGINS_PRIVILEGED: 'docker.io/woodpeckerci/plugin-docker-buildx:4.2.0'
+      WOODPECKER_PLUGINS_PRIVILEGED: 'docker.io/woodpeckerci/plugin-docker-buildx:5.0.0,docker.io/woodpeckerci/plugin-docker-buildx:latest'
   tags:
     - woodpecker
     - woodpecker-server


### PR DESCRIPTION
the docker-buildx plugin < 5.0.0 are insecure and should not be privileged by default