### PR TITLE
Use bash array in script to support multiple args

### DIFF
--- a/ansible.sh
+++ b/ansible.sh
@@ -11,8 +11,11 @@ else
   echo "✅ Image '$IMAGE_NAME' already exists. Skipping build."
 fi
 
-P="$@"
-CMD="${P:=ansible-playbook playbooks/run.yaml}"
+# Use default command if no arguments provided, otherwise use provided arguments
+if [ $# -eq 0 ]; then
+  CMD=(ansible-playbook playbooks/run.yaml)
+else
+  CMD=("$@")
+fi
 
-# shellcheck disable=SC2086
-$RUN_ANSIBLE $CMD
+$RUN_ANSIBLE "${CMD[@]}"


### PR DESCRIPTION
Use bash array to properly pass down multiple args to docker run. Tested with `./ansible.sh ansible-playbook playbooks/run.yaml --check -D` and `./ansible.sh`. 