### PR TITLE
Use full qualified container names

### DIFF
--- a/roles/caddy/tasks/main.yaml
+++ b/roles/caddy/tasks/main.yaml
@@ -17,7 +17,7 @@
     src: Caddyfile
     dest: /opt/caddy/Caddyfile
     mode: '0o644'
-  register: caddy_output
+  register: caddy_copy_conf
   tags:
     - caddy
 
@@ -37,9 +37,9 @@
   community.docker.docker_container:
     name: caddy
     hostname: caddy
-    image: caddy:{{ caddy_version }}
+    image: docker.io/caddy:{{ caddy_version }}
     restart_policy: 'always'
-    restart: true # To reload the Caddyfile in case the container wasn't updated
+    restart: '{{ caddy_copy_conf.changed }}'
     ports:
       - 80:80
       - 443:443

--- a/roles/vaultwarden/tasks/main.yaml
+++ b/roles/vaultwarden/tasks/main.yaml
@@ -8,9 +8,8 @@
   community.docker.docker_container:
     name: vaultwarden
     hostname: vaultwarden
-    image: vaultwarden/server:{{ vaultwarden_version }}
+    image: docker.io/vaultwarden/server:{{ vaultwarden_version }}
     restart_policy: 'always'
-    restart: true
     env:
       DOMAIN: 'https://vault.woodpecker-ci.org'
       SENDS_ALLOWED: 'false'

--- a/roles/weblate/tasks/main.yaml
+++ b/roles/weblate/tasks/main.yaml
@@ -34,7 +34,7 @@
     name: weblate_database
     hostname: weblate-database
     # renovate: datasource=docker depName=library/postgres
-    image: postgres:16-alpine
+    image: docker.io/postgres:16-alpine
     volumes:
       - weblate_postgres-data:/var/lib/postgresql/data
     restart_policy: 'always'
@@ -53,7 +53,7 @@
   community.docker.docker_container:
     name: weblate
     hostname: weblate
-    image: weblate/weblate:{{ weblate_version }}
+    image: docker.io/weblate/weblate:{{ weblate_version }}
     restart_policy: 'always'
     volumes:
       - weblate_weblate-data:/app/data

--- a/roles/woodpecker_agent/tasks/main.yaml
+++ b/roles/woodpecker_agent/tasks/main.yaml
@@ -12,7 +12,7 @@
     name: woodpecker_agent
     hostname: woodpecker_agent
     pull: 'always'
-    image: woodpeckerci/woodpecker-agent:{{ woodpecker_agent_version }}
+    image: docker.io/woodpeckerci/woodpecker-agent:{{ woodpecker_agent_version }}
     restart_policy: 'always'
     networks:
       - name: web

--- a/roles/woodpecker_autoscaler/tasks/main.yaml
+++ b/roles/woodpecker_autoscaler/tasks/main.yaml
@@ -3,7 +3,7 @@
     name: woodpecker_autoscaler
     hostname: woodpecker-autoscaler
     pull: 'always'
-    image: woodpeckerci/autoscaler:{{ woodpecker_autoscaler_version }}
+    image: docker.io/woodpeckerci/autoscaler:{{ woodpecker_autoscaler_version }}
     restart_policy: 'always'
     networks:
       - name: web
@@ -21,7 +21,7 @@
       WOODPECKER_HETZNERCLOUD_SSH_KEYS: '{{ woodpecker_autoscaler_hetzner_ssh_keys | string }}'
       WOODPECKER_HETZNERCLOUD_LOCATION: '{{ woodpecker_autoscaler_hetzner_location | string }}'
       WOODPECKER_RECONCILIATION_INTERVAL: 5s
-      WOODPECKER_AGENT_IMAGE: woodpeckerci/woodpecker-agent:{{ woodpecker_autoscaler_autoscaler_agent_version }}
+      WOODPECKER_AGENT_IMAGE: docker.io/woodpeckerci/woodpecker-agent:{{ woodpecker_autoscaler_autoscaler_agent_version }}
       WOODPECKER_AGENT_IDLE_TIMEOUT: 50m
   tags:
     - woodpecker

--- a/roles/woodpecker_server/tasks/main.yaml
+++ b/roles/woodpecker_server/tasks/main.yaml
@@ -12,7 +12,7 @@
     name: woodpecker_server
     hostname: woodpecker-server
     pull: 'always'
-    image: woodpeckerci/woodpecker-server:{{ woodpecker_server_version }}
+    image: docker.io/woodpeckerci/woodpecker-server:{{ woodpecker_server_version }}
     restart_policy: 'always'
     volumes:
       - /opt/woodpecker:/var/lib/woodpecker/


### PR DESCRIPTION
- Use full qualified container names
- remove `restart: true` when not needed or set it conditionally to restart containers only when needed and not on every ansible run